### PR TITLE
Added option for api version.

### DIFF
--- a/lib/desk.js
+++ b/lib/desk.js
@@ -5,6 +5,7 @@ var Client = function(config) {
   this.subdomain = config.subdomain;
   this.oauthToken = config.token;
   this.oauthTokenSecret = config.token_secret;
+  this.version = config.version || 'v1';
 
   this.oauth = new OAuth(
     null,
@@ -21,9 +22,9 @@ var Client = function(config) {
 
 Client.prototype.get = function(resource, params, callback) {
   return this.oauth.get(
-    'http://' + this.subdomain + '.desk.com/api/v1/' + resource + '?' + querystring.stringify(params),
-    this.oauthToken, 
-    this.oauthTokenSecret, 
+    'http://' + this.subdomain + '.desk.com/api/'+this.version+'/' + resource + '?' + querystring.stringify(params),
+    this.oauthToken,
+    this.oauthTokenSecret,
     function(error, data, response) {
       if(!error) data = JSON.parse(data);
       callback(error, data, response);


### PR DESCRIPTION
v1 is being deprecated in Dec. Just added an option to enable v2. Seems to be compatible but didn't have tests to run against.
